### PR TITLE
Changed Jetpack input to use MovementInput instead of key binding

### DIFF
--- a/src/main/java/stormedpanda/simplyjetpacks/handlers/KeybindHandler.java
+++ b/src/main/java/stormedpanda/simplyjetpacks/handlers/KeybindHandler.java
@@ -72,15 +72,15 @@ public class KeybindHandler {
         }
     }
 
-    private static void tickStart() {
+    private static void tickEnd() {
         Minecraft mc = Minecraft.getInstance();
         if (mc.player != null) {
-            boolean flyState = mc.gameSettings.keyBindJump.isKeyDown();
-            boolean descendState = mc.gameSettings.keyBindSneak.isKeyDown();
-            boolean forwardState = mc.gameSettings.keyBindForward.isKeyDown();
-            boolean backwardState = mc.gameSettings.keyBindBack.isKeyDown();
-            boolean leftState = mc.gameSettings.keyBindLeft.isKeyDown();
-            boolean rightState = mc.gameSettings.keyBindRight.isKeyDown();
+            boolean flyState = mc.player.movementInput.jump;
+            boolean descendState = mc.player.movementInput.sneaking;
+            boolean forwardState = mc.player.movementInput.forwardKeyDown;
+            boolean backwardState = mc.player.movementInput.backKeyDown;
+            boolean leftState = mc.player.movementInput.leftKeyDown;
+            boolean rightState = mc.player.movementInput.rightKeyDown;
             if (flyState != lastFlyState || descendState != lastDescendState || forwardState != lastForwardState || backwardState != lastBackwardState || leftState != lastLeftState || rightState != lastRightState) {
                 lastFlyState = flyState;
                 lastDescendState = descendState;
@@ -96,8 +96,8 @@ public class KeybindHandler {
 
     @SubscribeEvent
     public void onClientTick(TickEvent.ClientTickEvent evt) {
-        if (evt.phase == TickEvent.Phase.START) {
-            tickStart();
+        if (evt.phase == TickEvent.Phase.END) {
+            tickEnd();
         }
     }
 }


### PR DESCRIPTION
I currently develop a mod called Controllable and it enables support to play the Java Edition with a controller. I've made my best attempts to make sure the mod would work with most mods, however I've had a couple of reports that the jetpacks from this mod don't work. I took a quick look at how you gather the input and it was getting it directly from the keybind. 

This PR changes the input to be retrieved from `MovementInput` (which can be updated by Forge's `InputUpdateEvent`) and allows mods to make the player "jump" with code instead of relying on a physical key. If you see `MovementInputFromOptions#tickMovement` it's running the exactly the same code as in `KeybindHandler#tickStart`.

I did have to change the `ClientTickEvent` to the end phase as `InputUpdateEvent` is called after the start phase. From my testing there is no noticeable different in the behaviour.