### PR TITLE
Fix crash related to armor stands.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,10 @@ buildscript {
     }
 }
 
+plugins {
+  id "com.wynprice.cursemaven" version "2.1.5"
+}
+
 apply plugin: 'net.minecraftforge.gradle.forge'
 apply plugin: 'idea'
 apply plugin: 'maven'

--- a/src/main/java/tonius/simplyjetpacks/client/handler/ClientTickHandler.java
+++ b/src/main/java/tonius/simplyjetpacks/client/handler/ClientTickHandler.java
@@ -73,7 +73,8 @@ public class ClientTickHandler {
                     itr.remove();
                 } else {
                     ParticleType particle = SyncHandler.getJetpackStates().get(currentEntity);
-                    if (particle != null && !((EntityPlayer) entity).isSpectator()) {
+                    final boolean isSpectator = entity instanceof EntityPlayer && ((EntityPlayer) entity).isSpectator();
+                    if (particle != null && !isSpectator) {
                         if (entity.isInWater() && particle != ParticleType.NONE) {
                             particle = ParticleType.BUBBLE;
                         }


### PR DESCRIPTION
```
java.lang.ClassCastException: net.minecraft.entity.item.EntityArmorStand cannot be cast to net.minecraft.entity.player.EntityPlayer
    at tonius.simplyjetpacks.client.handler.ClientTickHandler.tickEnd(ClientTickHandler.java:76)
    at tonius.simplyjetpacks.client.handler.ClientTickHandler.onClientTick(ClientTickHandler.java:115)
    at net.minecraftforge.fml.common.eventhandler.ASMEventHandler_3132_ClientTickHandler_onClientTick_ClientTickEvent.invoke(.dynamic)
    at net.minecraftforge.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:90)
    at net.minecraftforge.fml.common.eventhandler.EventBus.post(EventBus.java:182)
    at net.minecraftforge.fml.common.FMLCommonHandler.onPostClientTick(FMLCommonHandler.java:349)
    at net.minecraft.client.Minecraft.runTick(Minecraft.java:1911)
    at net.minecraft.client.Minecraft.runGameLoop(Minecraft.java:1098)
    at net.minecraft.client.Minecraft.run(Minecraft.java:3942)
    at net.minecraft.client.main.Main.main(SourceFile:123)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
    at java.lang.reflect.Method.invoke(Unknown Source)
    at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
    at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
```